### PR TITLE
Fixed advanced_search_fields using old values

### DIFF
--- a/django_admin_search/admin.py
+++ b/django_admin_search/admin.py
@@ -30,6 +30,7 @@ class AdvancedSearchAdmin(ModelAdmin):
             return queryset.none()
 
     def changelist_view(self, request, extra_context=None):
+        self.advanced_search_fields = {}
         self.search_form_data = self.search_form(request.GET)
         self.extract_advanced_search_terms(request.GET)
         extra_context = {'asf': self.search_form_data}


### PR DESCRIPTION
**Issue:**
When submitting an empty search form (with no parameters), the previous filter is still used due to caching (not sure exactly if it's caching).

**How to reproduce:**
Create a form with a single non-required field:
```
class YourFormSearch(Form):
    my_filter = CharField(required=False, widget=TextInput(
        attrs={ 
            'filter_field': 'my_field',
            'filter_method': '__icontains',
        }
    ))
```
Apply the form to a model admin:
```
@register(YourModel)
class YourAdmin(AdvancedSearchAdmin):
    ...
    search_form = YourFormSearch
```
In the admin page, open the search form (`YouFormSearch`) and set some non-existing value for `my_filter` in order to get no results (empty queryset). Submit the search form. The page will have no results.
Open the search form again and leave `my_filter` empty. Submit the search form. The page will still have no results because it repeated the last value for `my_filter`. This is easily confirmed by looking at the value of https://github.com/shinneider/django-admin-search/blob/master/django_admin_search/admin.py#L16 everytime `get_queryset()` gets called. You'll see it still contains a value for `my_filter` even when submitting an empty form.
I imagine this happens due to caching.

**Suggestion for fix:**
This pull request contains a suggestion for a fix, but you might have a better idea on how to avoid values being kept on `advanced_search_fields` from previous requests.