### PR TITLE
Filter not working when field is empty #46

### DIFF
--- a/django_admin_search/admin.py
+++ b/django_admin_search/admin.py
@@ -58,7 +58,8 @@ class AdvancedSearchAdmin(ModelAdmin):
             check if field has value passed on request
         """
         if field in self.advanced_search_fields:
-            return True, self.advanced_search_fields[field][0]
+            value = self.advanced_search_fields[field][0]
+            return bool(value), value
 
         return False, None
 


### PR DESCRIPTION
This PR fixes issue https://github.com/shinneider/django-admin-search/issues/46.

When any field is empty in the queryset, the filter is not working as expected until __icontains is added to the filter_method.