### PR TITLE
fixed bug where `extra_context` was being truncated

### DIFF
--- a/django_admin_search/admin.py
+++ b/django_admin_search/admin.py
@@ -31,11 +31,12 @@ class AdvancedSearchAdmin(ModelAdmin):
         """
             Append custom form to page render
         """
+        extra_context = extra_context or {}
         if hasattr(self, 'search_form'):
             self.advanced_search_fields = {}
             self.search_form_data = self.search_form(request.GET.dict())
             self.extract_advanced_search_terms(request.GET)
-            extra_context = {'asf': self.search_form_data}
+            extra_context.update({'asf': self.search_form_data})
 
         return super().changelist_view(request, extra_context=extra_context)
 

--- a/django_admin_search/templates/admin/custom_search_form.html
+++ b/django_admin_search/templates/admin/custom_search_form.html
@@ -23,9 +23,11 @@
                                       {{ full_result_count }} total{% endblocktrans %}{% else %}{% trans "Show all" %}{% endif %}</a>)
             </span>
         {% endif %}
-        {% for pair in cl.params.items %}
-            {% if pair.0 != search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}"/>{% endif %}
-        {% endfor %}
+        {% if cl.params %}
+	        {% for pair in cl.params.items %}
+	            {% if pair.0 != search_var %}<input type="hidden" name="{{ pair.0 }}" value="{{ pair.1 }}"/>{% endif %}
+	        {% endfor %}
+        {% endif %}
         
         <div class="form_button_container">
             {% block modal_search_button %}


### PR DESCRIPTION
Fixed a bug where the "extra_context" variable was getting truncated before being passed onto the super().change_view(). It was problematic for some packages I was using. Now, the behavior is to inherit the extra_context var, and then update it as needed, preserving original data.